### PR TITLE
Add basic TravisCI configuration – closes #2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: node_js
+node_js:
+  - "node"
+  - "iojs"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: node_js
 node_js:
-  - "node"
-  - "iojs"
+  - node
+  - iojs
+matrix:
+  allow_failures:
+    - node_js: iojs


### PR DESCRIPTION
I also made the tests run against io.js but made it optional. If you don't care at all about io.js, I can remove it.
