### PR TITLE
Add coveralls reporting — closes #3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,7 @@ node_js:
 matrix:
   allow_failures:
     - node_js: iojs
+script:
+  - npm run test-cov
+after_script:
+  - npm run report-coverage

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "lint": "eslint .",
     "test": "NODE_ENV=test mocha --recursive -R spec",
     "posttest": "eslint .",
-    "test-cov": "istanbul cover node_modules/.bin/_mocha -- --recursive -R spec"
+    "test-cov": "istanbul cover node_modules/.bin/_mocha -- --recursive -R spec",
+    "report-coverage": "cat ./coverage/lcov.info | coveralls"
   },
   "repository": {
     "type": "git",
@@ -26,6 +27,7 @@
   "devDependencies": {
     "bluebird": "^3.1.1",
     "chai": "^3.4.1",
+    "coveralls": "^2.11.6",
     "eslint": "^1.10.3",
     "eslint-config-vinli": "^4.1.0",
     "eslint-plugin-mocha": "^1.1.0",


### PR DESCRIPTION
You just have to set the repo on https://coveralls.io (and eventually set the pull requests alerts).

![screenshot 2016-01-21 10 57 01](https://cloud.githubusercontent.com/assets/1788218/12477087/c7f96ad6-c02d-11e5-9303-b21fcb23a5fd.png)

![screenshot 2016-01-21 10 57 18](https://cloud.githubusercontent.com/assets/1788218/12477090/cb1064f4-c02d-11e5-94bc-602ad0a3c735.png)
